### PR TITLE
fix a memory subsystem

### DIFF
--- a/src/cgroups/blkio.rs
+++ b/src/cgroups/blkio.rs
@@ -140,7 +140,7 @@ mod tests {
     fn setup(testname: &str, throttle_type: &str) -> (PathBuf, PathBuf) {
         let tmp = create_temp_dir(testname).expect("create temp directory for test");
         let throttle_file = set_fixture(&tmp, throttle_type, "")
-            .expect(&format!("set fixture for {}", throttle_type));
+            .unwrap_or_else(|_| panic!("set fixture for {}", throttle_type));
 
         (tmp, throttle_file)
     }
@@ -182,7 +182,7 @@ mod tests {
 
         Blkio::apply(&test_root, &blkio).expect("apply blkio");
         let content = fs::read_to_string(throttle)
-            .expect(&format!("read {} content", CGROUP_BLKIO_THROTTLE_READ_BPS));
+            .unwrap_or_else(|_| panic!("read {} content", CGROUP_BLKIO_THROTTLE_READ_BPS));
 
         assert_eq!("8:0 102400", content);
     }
@@ -202,7 +202,7 @@ mod tests {
 
         Blkio::apply(&test_root, &blkio).expect("apply blkio");
         let content = fs::read_to_string(throttle)
-            .expect(&format!("read {} content", CGROUP_BLKIO_THROTTLE_WRITE_BPS));
+            .unwrap_or_else(|_| panic!("read {} content", CGROUP_BLKIO_THROTTLE_WRITE_BPS));
 
         assert_eq!("8:0 102400", content);
     }
@@ -222,7 +222,7 @@ mod tests {
 
         Blkio::apply(&test_root, &blkio).expect("apply blkio");
         let content = fs::read_to_string(throttle)
-            .expect(&format!("read {} content", CGROUP_BLKIO_THROTTLE_READ_IOPS));
+            .unwrap_or_else(|_| panic!("read {} content", CGROUP_BLKIO_THROTTLE_READ_IOPS));
 
         assert_eq!("8:0 102400", content);
     }
@@ -243,10 +243,8 @@ mod tests {
             .build();
 
         Blkio::apply(&test_root, &blkio).expect("apply blkio");
-        let content = fs::read_to_string(throttle).expect(&format!(
-            "read {} content",
-            CGROUP_BLKIO_THROTTLE_WRITE_IOPS
-        ));
+        let content = fs::read_to_string(throttle)
+            .unwrap_or_else(|_| panic!("read {} content", CGROUP_BLKIO_THROTTLE_WRITE_IOPS));
 
         assert_eq!("8:0 102400", content);
     }

--- a/src/cgroups/memory.rs
+++ b/src/cgroups/memory.rs
@@ -271,6 +271,18 @@ mod tests {
     }
 
     #[test]
+    fn pass_set_memory_if_limit_is_zero() {
+        let sample_val = "1024";
+        let limit = 0;
+        let tmp = create_temp_dir("test_set_memory").expect("create temp directory for test");
+        set_fixture(&tmp, CGROUP_MEMORY_LIMIT, sample_val).expect("Set fixure for memory limit");
+        Memory::set_memory(limit, &tmp).expect("Set memory limit");
+        let content =
+            std::fs::read_to_string(tmp.join(CGROUP_MEMORY_LIMIT)).expect("Read to string");
+        assert_eq!(content, sample_val)
+    }
+
+    #[test]
     fn test_set_swap() {
         let limit = 512;
         let tmp = create_temp_dir("test_set_swap").expect("create temp directory for test");

--- a/src/cgroups/memory.rs
+++ b/src/cgroups/memory.rs
@@ -274,7 +274,8 @@ mod tests {
     fn pass_set_memory_if_limit_is_zero() {
         let sample_val = "1024";
         let limit = 0;
-        let tmp = create_temp_dir("test_set_memory").expect("create temp directory for test");
+        let tmp = create_temp_dir("pass_set_memory_if_limit_is_zero")
+            .expect("create temp directory for test");
         set_fixture(&tmp, CGROUP_MEMORY_LIMIT, sample_val).expect("Set fixure for memory limit");
         Memory::set_memory(limit, &tmp).expect("Set memory limit");
         let content =

--- a/src/cgroups/memory.rs
+++ b/src/cgroups/memory.rs
@@ -147,6 +147,9 @@ impl Memory {
     }
 
     fn set_memory(val: i64, cgroup_root: &Path) -> Result<()> {
+        if val == 0 {
+            return Ok(());
+        }
         let path = cgroup_root.join(CGROUP_MEMORY_LIMIT);
 
         match Self::set(val, &path) {
@@ -158,16 +161,16 @@ impl Memory {
                         Errno::EBUSY => {
                             let usage = Self::get_memory_usage(cgroup_root)?;
                             let max_usage = Self::get_memory_max_usage(cgroup_root)?;
-                            Err(anyhow!(
+                            bail!(
                                     "unable to set memory limit to {} (current usage: {}, peak usage: {})",
                                     val,
                                     usage,
                                     max_usage,
-                            ))
+                            )
                         }
-                        _ => Err(anyhow!(e)),
+                        _ => bail!(e),
                     },
-                    None => Err(anyhow!(e)),
+                    None => bail!(e),
                 }
             }
         }
@@ -225,12 +228,8 @@ impl Memory {
                 }
             }
             None => match resource.swap {
-                Some(swap) => {
-                    Self::set_memory_and_swap(0, swap, false, cgroup_root)?;
-                }
-                None => {
-                    Self::set_memory_and_swap(0, 0, false, cgroup_root)?;
-                }
+                Some(swap) => Self::set_memory_and_swap(0, swap, false, cgroup_root)?,
+                None => Self::set_memory_and_swap(0, 0, false, cgroup_root)?,
             },
         }
         Ok(())

--- a/src/cgroups/network_priority.rs
+++ b/src/cgroups/network_priority.rs
@@ -97,11 +97,7 @@ mod tests {
                 priority: 2,
             },
         ];
-        let priorities_string = priorities
-            .clone()
-            .iter()
-            .map(|p| p.to_string())
-            .collect::<String>();
+        let priorities_string = priorities.iter().map(|p| p.to_string()).collect::<String>();
         let network = LinuxNetwork {
             class_id: None,
             priorities,


### PR DESCRIPTION
I ran it with Docker and youki at local, and it didn't work because it tried to set 0, so I fixed it.
https://github.com/opencontainers/runc/blob/3f6594675675d4e88901c782462f56497260b1d2/libcontainer/cgroups/fs/memory.go#L40-L42