### PR TITLE
Update Rust-Analyzer in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:1
 WORKDIR /workspaces
 RUN curl -fsSL get.docker.com -o get-docker.sh && sh get-docker.sh && rm get-docker.sh
 RUN rustup component add rust-src clippy
-RUN curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-linux -o /usr/local/cargo/bin/rust-analyzer && chmod +x /usr/local/cargo/bin/rust-analyzer
+RUN curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz -o /usr/local/cargo/bin/rust-analyzer.gz 
+RUN gzip -d /usr/local/cargo/bin/rust-analyzer.gz && chmod +x /usr/local/cargo/bin/rust-analyzer
 RUN wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.13.5.linux-amd64.tar.gz
 RUN mkdir /workspaces/go
 ENV PATH $PATH:/usr/local/go/bin

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,9 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:1
 WORKDIR /workspaces
 RUN curl -fsSL get.docker.com -o get-docker.sh && sh get-docker.sh && rm get-docker.sh
 RUN rustup component add rust-src clippy
-RUN curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz -o /usr/local/cargo/bin/rust-analyzer.gz 
-RUN gzip -d /usr/local/cargo/bin/rust-analyzer.gz && chmod +x /usr/local/cargo/bin/rust-analyzer
+RUN curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz \
+    -o /usr/local/cargo/bin/rust-analyzer.gz && gzip -d /usr/local/cargo/bin/rust-analyzer.gz \
+    && chmod +x /usr/local/cargo/bin/rust-analyzer
 RUN wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.13.5.linux-amd64.tar.gz
 RUN mkdir /workspaces/go
 ENV PATH $PATH:/usr/local/go/bin


### PR DESCRIPTION
Hi all, 

I noticed while checking out Youki that Rust-Analyzer was failing to install. The project did not release an uncompressed binary with the latest release. Based on this [Pull Request](https://github.com/rust-analyzer/rust-analyzer/pull/8926) it seems the project will not be uploading uncompressed binaries going forward.

I did a quick edit to the docker file so it now points toward the latest  `rust-analyzer-x86_64-unknown-linux-gnu.gz`  and uses gzip to decompress the binary in `/usr/local/cargo/bin/rust-analyzer`.