### PR TITLE
add default handling when there isn't cgroup path in config.json.

### DIFF
--- a/oci_spec/src/lib.rs
+++ b/oci_spec/src/lib.rs
@@ -568,7 +568,7 @@ pub struct Linux {
     pub sysctl: HashMap<String, String>,
     pub resources: Option<LinuxResources>,
     #[serde(default)]
-    pub cgroups_path: PathBuf,
+    pub cgroups_path: Option<PathBuf>,
     #[serde(default)]
     pub namespaces: Vec<LinuxNamespace>,
     #[serde(default)]

--- a/src/cgroups/manager.rs
+++ b/src/cgroups/manager.rs
@@ -5,13 +5,13 @@ use anyhow::Result;
 use nix::unistd::Pid;
 use procfs::process::Process;
 
-use crate::{cgroups::ControllerType,  utils::PathBufExt};
-use oci_spec::LinuxResources;
 use super::{
     blkio::Blkio, devices::Devices, hugetlb::Hugetlb, memory::Memory,
     network_classifier::NetworkClassifier, network_priority::NetworkPriority, pids::Pids,
     Controller,
 };
+use crate::{cgroups::ControllerType, utils::PathBufExt};
+use oci_spec::LinuxResources;
 
 const CONTROLLERS: &[ControllerType] = &[
     ControllerType::Devices,
@@ -28,12 +28,12 @@ pub struct Manager {
 }
 
 impl Manager {
-    pub fn new(cgroup_path: PathBuf) -> Result<Self> {
+    pub fn new(cgroup_path: &Path) -> Result<Self> {
         let mut subsystems = HashMap::<String, PathBuf>::new();
         for subsystem in CONTROLLERS.iter().map(|c| c.to_string()) {
             subsystems.insert(
                 subsystem.to_owned(),
-                Self::get_subsystem_path(&cgroup_path, &subsystem)?,
+                Self::get_subsystem_path(cgroup_path, &subsystem)?,
             );
         }
 

--- a/src/create.rs
+++ b/src/create.rs
@@ -14,7 +14,6 @@ use crate::namespaces::Namespaces;
 use crate::notify_socket::NotifyListener;
 use crate::process::{fork, Process};
 use crate::rootfs;
-use oci_spec;
 use crate::stdio::FileDescriptor;
 use crate::tty;
 use crate::utils;
@@ -102,7 +101,9 @@ fn run_container<P: AsRef<Path>>(
     let linux = spec.linux.as_ref().unwrap();
     let namespaces: Namespaces = linux.namespaces.clone().into();
 
-    let cmanager = cgroups::Manager::new(linux.cgroups_path.clone())?;
+    let cgroups_path = utils::get_cgroup_path(&linux.cgroups_path, container.id());
+
+    let cmanager = cgroups::Manager::new(&cgroups_path)?;
 
     match fork::fork_first(
         pid_file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use youki::container::{Container, ContainerStatus};
 use youki::create;
 use youki::signal;
 use youki::start;
+use youki::utils;
 use youki::{cgroups::Manager, command::linux::LinuxCommand};
 
 /// High-level commandline option definition
@@ -140,14 +141,18 @@ fn main() -> Result<()> {
             if container.can_delete() {
                 if container.root.exists() {
                     // remove the directory storing container state
+                    log::debug!("remove dir {:?}", container.root);
                     fs::remove_dir_all(&container.root)?;
-                  
+
                     let spec = oci_spec::Spec::load("config.json")?;
+
+                    let cgroups_path =
+                        utils::get_cgroup_path(&spec.linux.unwrap().cgroups_path, container.id());
+
                     // remove the cgroup created for the container
                     // check https://man7.org/linux/man-pages/man7/cgroups.7.html
                     // creating and removing cgroups section for more information on cgroups
-                  
-                    let cmanager = Manager::new(spec.linux.unwrap().cgroups_path)?;
+                    let cmanager = Manager::new(&cgroups_path)?;
                     cmanager.remove()?;
                 }
                 std::process::exit(0)

--- a/src/process/fork.rs
+++ b/src/process/fork.rs
@@ -15,7 +15,6 @@ use nix::unistd;
 use crate::cgroups::Manager;
 use crate::container::ContainerStatus;
 use crate::process::{child, init, parent, Process};
-use oci_spec;
 use crate::utils;
 use crate::{cond::Cond, container::Container};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,6 +64,14 @@ pub fn set_name(_name: &str) -> Result<()> {
     Ok(())
 }
 
+/// If None, it will generate a default path for cgroups.
+pub fn get_cgroup_path(cgroups_path: &Option<PathBuf>, container_id: &str) -> PathBuf {
+    match cgroups_path {
+        Some(cpath) => cpath.clone(),
+        None => PathBuf::from(format!("/youki/{}", container_id)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,6 +93,19 @@ mod tests {
                 .join_absolute_path(&PathBuf::from("b/c"))
                 .is_err(),
             true
+        );
+    }
+
+    #[test]
+    fn test_get_cgroup_path() {
+        let cid = "sample_container_id";
+        assert_eq!(
+            get_cgroup_path(&None, cid),
+            PathBuf::from("/youki/sample_container_id")
+        );
+        assert_eq!(
+            get_cgroup_path(&Some(PathBuf::from("/youki")), cid),
+            PathBuf::from("/youki")
         );
     }
 }


### PR DESCRIPTION
Fixed the problem of using the cgroup root when cgroup path isn't in config.json.