### PR TITLE
organize the logger.

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -9,53 +9,30 @@ use std::{
 use anyhow::Result;
 use log::{LevelFilter, Log, Metadata, Record};
 use once_cell::sync::OnceCell;
-use serde_json::json;
 
 pub static YOUKI_LOGGER: OnceCell<YoukiLogger> = OnceCell::new();
 pub static LOG_FILE: OnceCell<Option<File>> = OnceCell::new();
 
-pub fn init(container_id: &str, log_file: Option<PathBuf>) -> Result<()> {
+pub fn init(log_file: Option<PathBuf>) -> Result<()> {
     let _log_file = LOG_FILE.get_or_init(|| -> Option<File> {
-        if let Ok(docker_root) = env::var("YOUKI_MODE") {
-            if let Some(log_file_path) = &log_file {
-                OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(false)
-                    .open(log_file_path)
-                    .expect("fail opening log file ");
-            };
+        let level_filter = if let Ok(log_level_str) = env::var("YOUKI_LOG_LEVEL") {
+            LevelFilter::from_str(&log_level_str).unwrap_or(LevelFilter::Warn)
+        } else {
+            LevelFilter::Warn
+        };
 
-            let mut log_file_path = PathBuf::from(&docker_root);
-            log_file_path.push(container_id);
-            log_file_path.push(format!("{}-json.log", container_id));
-
-            let level_filter = if let Ok(log_level_str) = env::var("YOUKI_LOG_LEVEL") {
-                LevelFilter::from_str(&log_level_str).unwrap_or(LevelFilter::Warn)
-            } else {
-                LevelFilter::Warn
-            };
-            let logger = YOUKI_LOGGER.get_or_init(|| YoukiLogger::new(level_filter.to_level()));
-            log::set_logger(logger)
-                .map(|()| log::set_max_level(level_filter))
-                .unwrap();
+        let logger = YOUKI_LOGGER.get_or_init(|| YoukiLogger::new(level_filter.to_level()));
+        log::set_logger(logger)
+            .map(|()| log::set_max_level(level_filter))
+            .expect("set logger failed");
+        log_file.as_ref().map(|log_file_path| {
             OpenOptions::new()
                 .create(true)
                 .write(true)
                 .truncate(false)
                 .open(log_file_path)
-                .map_err(|e| eprintln!("{:?}", e))
-                .ok()
-        } else {
-            log_file.map(|log_file_path| {
-                OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(false)
-                    .open(log_file_path)
-                    .expect("fail opening log file ")
-            })
-        }
+                .expect("fail opening log file ")
+        })
     });
     Ok(())
 }
@@ -81,21 +58,25 @@ impl Log for YoukiLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             let log_msg = match (record.file(), record.line()) {
-                (Some(file), Some(line)) => json!({
-                    "log": format!("[{} {}:{}] {}\r\n", record.level(), file, line, record.args()),
-                    "stream": "stdout",
-                    "time": chrono::Local::now().to_rfc3339()
-                }),
-                (_, _) => json!({
-                    "log": format!("[{}] {}\r\n", record.level(), record.args()),
-                    "stream": "stdout",
-                    "time": chrono::Local::now().to_rfc3339()
-                }),
+                (Some(file), Some(line)) => format!(
+                    "[{} {}:{}] {} {}\r",
+                    record.level(),
+                    file,
+                    line,
+                    chrono::Local::now().to_rfc3339(),
+                    record.args()
+                ),
+                (_, _) => format!(
+                    "[{}] {} {}\r",
+                    record.level(),
+                    chrono::Local::now().to_rfc3339(),
+                    record.args()
+                ),
             };
             if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
-                let _ = writeln!(log_file, "{}", log_msg.to_string());
+                let _ = writeln!(log_file, "{}", log_msg);
             } else {
-                let _ = writeln!(stderr(), "{}", log_msg.to_string());
+                let _ = writeln!(stderr(), "{}", log_msg);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,33 +65,13 @@ enum SubCommand {
     State(StateArgs),
 }
 
-impl SubCommand {
-    fn get_container_id(&self) -> &String {
-        match &self {
-            SubCommand::Create(create) => &create.container_id,
-            SubCommand::Start(start) => &start.container_id,
-            SubCommand::Delete(delete) => &delete.container_id,
-            SubCommand::Kill(kill) => &kill.container_id,
-            SubCommand::State(state_args) => &state_args.container_id,
-        }
-    }
-}
-
 /// This is the entry point in the container runtime. The binary is run by a high-level container runtime,
 /// with various flags passed. This parses the flags, creates and manages appropriate resources.
 fn main() -> Result<()> {
     let opts = Opts::parse();
 
-    // debug mode for developer
-    if matches!(opts.subcmd, SubCommand::Create(_)) {
-        #[cfg(debug_assertions)]
-        std::env::set_var("YOUKI_MODE", "/var/lib/docker/containers/");
-        #[cfg(debug_assertions)]
-        std::env::set_var("YOUKI_LOG_LEVEL", "debug");
-    }
-
-    if let Err(e) = youki::logger::init(opts.subcmd.get_container_id().as_str(), opts.log) {
-        log::warn!("log init failed: {:?}", e);
+    if let Err(e) = youki::logger::init(opts.log) {
+        eprintln!("log init failed: {:?}", e);
     }
 
     let root_path = PathBuf::from(&opts.root);


### PR DESCRIPTION
Originally, in order to support docker in the early development stage, we used `docker logs $container_id` to show youki logs.
However, this is a bit complicated and too dependent on docker, so we will remove it.