### PR TITLE
Align cgroup controller implementations

### DIFF
--- a/src/cgroups/common.rs
+++ b/src/cgroups/common.rs
@@ -38,18 +38,8 @@ impl Display for Cgroup {
     }
 }
 
-pub fn write_cgroup_file_truncate(path: &Path, data: &str) -> Result<()> {
-    fs::OpenOptions::new()
-        .create(false)
-        .write(true)
-        .truncate(true)
-        .open(path)?
-        .write_all(data.as_bytes())?;
-
-    Ok(())
-}
-
-pub fn write_cgroup_file(path: &Path, data: &str) -> Result<()> {
+#[inline]
+pub fn write_cgroup_file<P: AsRef<Path>>(path: P, data: &str) -> Result<()> {
     fs::OpenOptions::new()
         .create(false)
         .write(true)
@@ -94,7 +84,7 @@ pub fn create_cgroup_manager<P: Into<PathBuf>>(cgroup_path: P) -> Result<Box<dyn
                     )?))
                 }
                 _ => Ok(Box::new(v1::manager::Manager::new(cgroup_path.into())?)),
-            }
+            } 
         }
         _ => bail!("could not find cgroup filesystem"),
     }

--- a/src/cgroups/v1/devices.rs
+++ b/src/cgroups/v1/devices.rs
@@ -1,12 +1,9 @@
-use std::io::Write;
-use std::{
-    fs::{create_dir_all, OpenOptions},
-    path::Path,
-};
+use std::{fs::create_dir_all, path::Path};
 
 use anyhow::Result;
 use nix::unistd::Pid;
 
+use crate::cgroups::common;
 use crate::{cgroups::v1::Controller, rootfs::default_devices};
 use oci_spec::{LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 
@@ -30,12 +27,7 @@ impl Controller for Devices {
             Self::apply_device(&d, &cgroup_root)?;
         }
 
-        OpenOptions::new()
-            .create(false)
-            .write(true)
-            .truncate(false)
-            .open(cgroup_root.join("cgroup.procs"))?
-            .write_all(pid.to_string().as_bytes())?;
+        common::write_cgroup_file(cgroup_root.join("cgroup.procs"), &pid.to_string())?;
         Ok(())
     }
 }
@@ -48,12 +40,7 @@ impl Devices {
             cgroup_root.join("devices.deny")
         };
 
-        OpenOptions::new()
-            .create(false)
-            .write(true)
-            .truncate(false)
-            .open(path)?
-            .write_all(device.to_string().as_bytes())?;
+        common::write_cgroup_file(path, &device.to_string())?;
         Ok(())
     }
 

--- a/src/cgroups/v1/manager.rs
+++ b/src/cgroups/v1/manager.rs
@@ -12,7 +12,7 @@ use super::{
     Controller,
 };
 
-use crate::{cgroups::v1::ControllerType, cgroups::common::CgroupManager, utils::PathBufExt};
+use crate::{cgroups::common::CgroupManager, cgroups::v1::ControllerType, utils::PathBufExt};
 use oci_spec::LinuxResources;
 
 const CONTROLLERS: &[ControllerType] = &[

--- a/src/cgroups/v1/network_priority.rs
+++ b/src/cgroups/v1/network_priority.rs
@@ -1,12 +1,9 @@
-use std::io::Write;
-use std::{
-    fs::{create_dir_all, OpenOptions},
-    path::Path,
-};
+use std::{fs::create_dir_all, path::Path};
 
 use anyhow::Result;
 use nix::unistd::Pid;
 
+use crate::cgroups::common;
 use crate::cgroups::v1::Controller;
 use oci_spec::{LinuxNetwork, LinuxResources};
 
@@ -19,15 +16,9 @@ impl Controller for NetworkPriority {
 
         if let Some(network) = linux_resources.network.as_ref() {
             Self::apply(cgroup_root, network)?;
-
-            OpenOptions::new()
-                .create(false)
-                .write(true)
-                .truncate(true)
-                .open(cgroup_root.join("cgroup.procs"))?
-                .write_all(pid.to_string().as_bytes())?;
         }
 
+        common::write_cgroup_file(cgroup_root.join("cgroup.procs"), &pid.to_string())?;
         Ok(())
     }
 }
@@ -35,18 +26,7 @@ impl Controller for NetworkPriority {
 impl NetworkPriority {
     fn apply(root_path: &Path, network: &LinuxNetwork) -> Result<()> {
         let priorities: String = network.priorities.iter().map(|p| p.to_string()).collect();
-        Self::write_file(&root_path.join("net_prio.ifpriomap"), &priorities.trim())?;
-
-        Ok(())
-    }
-
-    fn write_file(file_path: &Path, data: &str) -> Result<()> {
-        OpenOptions::new()
-            .create(false)
-            .write(true)
-            .truncate(true)
-            .open(file_path)?
-            .write_all(data.as_bytes())?;
+        common::write_cgroup_file(&root_path.join("net_prio.ifpriomap"), &priorities.trim())?;
 
         Ok(())
     }
@@ -54,7 +34,7 @@ impl NetworkPriority {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{io::Write, path::PathBuf};
 
     use super::*;
     use oci_spec::LinuxInterfacePriority;


### PR DESCRIPTION
There are multiple identical write file helper methods throughout the cgroup controller implementations. This PR replaces them with the write file helper method from the common module. Sometimes files were truncated before being written to, but this should not be necessary for cgroup files.

It also ensures that the container pid is written to the cgroup.procs file regardless if the controller has to apply resource restrictions or not. Some controllers did this, some did not. That way the cgroup can be used to track the resource consumption which some monitoring tools might rely on. It is also consistent with the behavior of runc.