### PR TITLE
Possible fix for getting exit code from exec command

### DIFF
--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -15,10 +15,7 @@ use nix::unistd::setsid;
 use nix::unistd::{self, Gid, Uid};
 use oci_spec::runtime::{LinuxNamespaceType, Spec, User};
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Write;
 use std::os::unix::io::AsRawFd;
-use std::os::unix::prelude::FromRawFd;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -162,7 +159,6 @@ pub fn container_init_process(
     args: &ContainerArgs,
     main_sender: &mut channel::MainSender,
     init_receiver: &mut channel::InitReceiver,
-    fifo_fd: i32,
 ) -> Result<()> {
     let syscall = args.syscall;
     let spec = args.spec;
@@ -417,11 +413,7 @@ pub fn container_init_process(
 
     if proc.args().is_some() {
         ExecutorManager::exec(spec)?;
-        if fifo_fd != 0 {
-            let f = &mut unsafe { File::from_raw_fd(fifo_fd) };
-            // TODO: impl
-            write!(f, "1")?;
-        }
+        // will never reach here, as exec will replcae the process image
         Ok(())
     } else {
         bail!("on non-Windows, at least one process arg entry is required")

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -14,7 +14,6 @@ pub fn container_intermediate_process(
     intermediate_chan: &mut (channel::IntermediateSender, channel::IntermediateReceiver),
     init_chan: &mut (channel::InitSender, channel::InitReceiver),
     main_sender: &mut channel::MainSender,
-    fifo_fd: i32,
 ) -> Result<()> {
     let (inter_sender, inter_receiver) = intermediate_chan;
     let (init_sender, init_receiver) = init_chan;
@@ -96,7 +95,7 @@ pub fn container_intermediate_process(
         inter_sender
             .close()
             .context("failed to close sender in the intermediate process")?;
-        container_init_process(args, main_sender, init_receiver, fifo_fd)
+        container_init_process(args, main_sender, init_receiver)
     })?;
     // Once we fork the container init process, the job for intermediate process
     // is done. We notify the container main process about the pid we just

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -6,11 +6,8 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use nix::{
-    sys::{
-        socket::{self, UnixAddr},
-        stat,
-    },
-    unistd::{self, mkfifo, Pid},
+    sys::socket::{self, UnixAddr},
+    unistd::{self, Pid},
 };
 use oci_spec::runtime;
 use std::{io::IoSlice, path::Path};
@@ -25,32 +22,12 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
     let inter_chan = &mut channel::intermediate_channel()?;
     let init_chan = &mut channel::init_channel()?;
 
-    // TODO: implement Option version
-    let mut fifo_fd = 0;
-    // let container_root = &container_args
-    //     .container
-    //     .as_ref()
-    //     .context("container state is required")?
-    //     .root;
-    let container_root = &std::path::Path::new("/run/youki/tutorial_container/");
-    let fifo_path = container_root.join("state.fifo");
-    if container_args.init {
-        mkfifo(&fifo_path, stat::Mode::S_IRWXU).context("failed to create the fifo file.")?;
-    }
-
-    let mut open_flags = nix::fcntl::OFlag::empty();
-    open_flags.insert(nix::fcntl::OFlag::O_PATH);
-    open_flags.insert(nix::fcntl::OFlag::O_CLOEXEC);
-    fifo_fd = nix::fcntl::open(&fifo_path, open_flags, stat::Mode::S_IRWXU)?;
-    log::debug!("fifo_fd: {}", fifo_fd);
-
     let intermediate_pid = fork::container_fork(|| {
         container_intermediate_process::container_intermediate_process(
             container_args,
             inter_chan,
             init_chan,
             main_sender,
-            fifo_fd,
         )
     })?;
     // Close down unused fds. The corresponding fds are duplicated to the

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -3,15 +3,12 @@ use nix::{
     libc,
     poll::{PollFd, PollFlags},
 };
-use std::{fs::OpenOptions, io::Read, os::unix::prelude::RawFd, path::PathBuf};
+use std::{os::unix::prelude::RawFd, path::PathBuf};
 
 use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::create_syscall};
 use liboci_cli::Exec;
 
-use super::load_container;
-
 pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
-    let container = load_container(&root_path, &args.container_id)?;
     let syscall = create_syscall();
     let pid = ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
         .with_root_path(root_path)?
@@ -28,16 +25,18 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
     let pidfd = pidfd_open(pid.as_raw(), 0)?;
     let poll_fd = PollFd::new(pidfd, PollFlags::POLLIN);
     nix::poll::poll(&mut [poll_fd], -1).context("failed to wait for the container id")?;
+    dbg!("pid of container process = {}", pid);
+    let p = procfs::process::Process::new(pid.into())?;
+    let stats = p.stat()?;
+    let code = stats.exit_code;
+    let sig = stats.exit_signal;
+    dbg!("got values {:?} {:?}", code.map(|v| v / 256), sig);
 
-    let fifo_path = &container.root.join("state.fifo");
-    println!("fifo_path: {:?}", fifo_path);
-    let mut f = OpenOptions::new().read(true).open(fifo_path)?;
-    let mut contents = String::new();
-    f.read_to_string(&mut contents)?;
-    println!("get the value: {:?}", contents);
-
-    // TODO
-    Ok(0)
+    // check accepted answer of https://stackoverflow.com/questions/18441760/linux-where-are-the-return-codes-stored-of-system-daemons-and-other-processes
+    // to see why we divide by 256
+    // also this is not perfect, in testing I once got IO error saying the proc directory does not exit, which means there can be
+    // and likely will be a race condition in process exiting and we trying to read the exit code, so this is probably not perfect
+    Ok(code.map(|v| v / 256).unwrap())
 }
 
 fn pidfd_open(pid: libc::pid_t, flags: libc::c_uint) -> Result<RawFd> {


### PR DESCRIPTION
Hey, I took a look at the PR https://github.com/containers/youki/pull/1018 ,  and making this PR here to suggest possible changes. This is by no means a complete solution, but should hopefully provide some way to go forward.

Originally I had also though of using the pipe based way as this, but I have changed it. The reason behind this is - to make the pipe way work, some process has to wait for the init process (which runs the exec command) to exit, catch its code and write it to the pipe. The init cannot do it itself, as after exec-ing, the process image is replaced. One way to get the exit status is to do a `wait` or `waitpid` , but both only work on child processes or spanwed thread, and as the original youki process which spawned the init process has exited, the process sending exec message cannot use these to wait on the init process.

After seeing the poll on process fd, and reading https://stackoverflow.com/questions/18441760/linux-where-are-the-return-codes-stored-of-system-daemons-and-other-processes , I thought as we are waiting for the process to exit, we can read the exit code in the waiting process itself, thus not needing an intermediate pipe at all. Although this has issues, notably once in my several test runs, it gave IO error, directory in /proc does not exists ; indicating this is susceptible to race-conditions.

Hope this helps a bit :)

<a href="https://gitpod.io/#https://github.com/utam0k/youki/pull/110"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

