### PR TITLE
fix initial provisions always running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 	./scripts/clean.sh $(ROOT)
 
 containerd-test:
-	VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant up --provision-with bootstrap | true
+	VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant up
 	VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant provision --provision-with test
 
 

--- a/Vagrantfile.containerd2youki
+++ b/Vagrantfile.containerd2youki
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.provider "virtualbox" do |v|
       v.memory = 4096
-      v.cpus = 2
+      v.cpus = 4
     end
 
     config.vm.provision "bootstrap", type: "shell" do |s|
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
           cd /root/go/src/github.com/containerd/containerd/
           export PATH=$PATH:$HOME/.cargo/bin:/usr/local/go/bin
           make TEST_RUNTIME=io.containerd.runc.v2 TESTFLAGS="-timeout 120m" integration | tee result.txt
-          grep "FAIL: " result.txt
+          grep "FAIL: " result.txt || true
         SHELL
     end
 end


### PR DESCRIPTION
This should make your PR on this good to go.
Now the initial install-setup will run only once when the vm is created for the first time, and the final grep will not fail if all tests pass.
Also increases cpu number to 4, as it take quite a long on 2 :sweat_smile: 